### PR TITLE
set redis container_name

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,7 +3,7 @@ ethercalc:
   ports:
     - "80:8000"
   links:
-    - redis
+    - redis:redis
   restart: always
 redis:
   image: redis:latest


### PR DESCRIPTION
Dockerfile uses $REDIS_PORT_6379_TCP_ADDR and $REDIS_PORT_6379_TCP_PORT. The redis's container name maybe not redis. So add an alias in links.
